### PR TITLE
Simplify homepage and link downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,32 +29,11 @@
         <hr>
 
         <section id="main_content">
-          <h3>Welcome to GitHub Pages.</h3>
+          <h3>pyenv downloads</h3>
 
-<p>This automatic page generator is the easiest way to create beautiful pages for all of your projects. Author your page content here using GitHub Flavored Markdown, select a template crafted by a designer, and publish. After your page is generated, you can check out the new branch:</p>
+<p>Browse the <a href="/pythons/">official python-build download mirror</a>.</p>
 
-<pre><code>$ cd your_repo_root/repo_name
-$ git fetch origin
-$ git checkout gh-pages
-</code></pre>
-
-<p>If you're using the GitHub for Mac, simply sync your repository and you'll see the new branch.</p>
-
-<h3>Designer Templates</h3>
-
-<p>We've crafted some handsome templates for you to use. Go ahead and continue to layouts to browse through them. You can easily go back to edit your page before publishing. After publishing your page, you can revisit the page generator and switch to another theme. Your Page content will be preserved if it remained markdown format.</p>
-
-<h3>Rather Drive Stick?</h3>
-
-<p>If you prefer to not use the automatic generator, push a branch named <code>gh-pages</code> to your repository to create a page manually. In addition to supporting regular HTML content, GitHub Pages support Jekyll, a simple, blog aware static site generator written by our own Tom Preston-Werner. Jekyll makes it easy to create site-wide headers and footers without having to copy them across every page. It also offers intelligent blog support and other advanced templating features.</p>
-
-<h3>Authors and Contributors</h3>
-
-<p>You can <a href="https://github.com/blog/821" class="user-mention">@mention</a> a GitHub username to generate a link to their profile. The resulting <code>&lt;a&gt;</code> element will link to the contributor's GitHub Profile. For example: In 2007, Chris Wanstrath (<a href="https://github.com/defunkt" class="user-mention">@defunkt</a>), PJ Hyett (<a href="https://github.com/pjhyett" class="user-mention">@pjhyett</a>), and Tom Preston-Werner (<a href="https://github.com/mojombo" class="user-mention">@mojombo</a>) founded GitHub.</p>
-
-<h3>Support or Contact</h3>
-
-<p>Having trouble with Pages? Check out the documentation at <a href="http://help.github.com/pages">http://help.github.com/pages</a> or contact <a href="mailto:support@github.com">support@github.com</a> and we’ll help you sort it out.</p>
+<p>For documentation and source code, visit the <a href="https://github.com/pyenv/pyenv">pyenv repository</a>.</p>
         </section>
 
         <footer>


### PR DESCRIPTION
## What

Replace the default GitHub Pages instructions on the homepage with links to the existing Python archive mirror and the pyenv repository.

## Why

The homepage still showed the starter template and did not link to the downloads page.

## How

Update only `index.html` and keep the existing theme unchanged.

Part of pyenv/pyenv#2334.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the homepage by replacing the default GitHub Pages template with a minimal downloads view linking to the python-build mirror and the `pyenv` repository. Previously the homepage showed starter instructions; now it shows “pyenv downloads” with direct links. No theme changes.

- Updates only `index.html`; no layout, assets, or config changes.
- Verify the mirror link at /pythons/ and the repository link to https://github.com/pyenv/pyenv.
- No redirects or navigation changes beyond homepage content.

<sup>Written for commit ed29d94627454feb033c87bff0534823a21249a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv.github.io/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

