### PR TITLE
Add prebuilt CPython download index

### DIFF
--- a/pythons/index.html
+++ b/pythons/index.html
@@ -41,15 +41,15 @@ uses <a href="http://pyenv.github.io/pythons">http://pyenv.github.io/pythons</a>
 $ pyenv install 2.7.7
 </code></pre>
 
-<p>The filenames of the mirrored archives are their SHA-256 checksums.
-The following links are the contents of the pyenv's official mirror of Python archives.</p>
-
           <h3>Prebuilt CPython</h3>
 
-<p>Prebuilt CPython archives and their python-build definitions.</p>
+<p>Prebuilt CPython archives and their python-build definitions use stable filenames.</p>
 
           <ul id="prebuilt-cpython">
           </ul>
+
+<p>The filenames of the source archives below are their SHA-256 checksums.
+The following links are the contents of the pyenv's official mirror of Python archives.</p>
 
           <h3>Stackless 2.7</h3>
 

--- a/pythons/index.html
+++ b/pythons/index.html
@@ -41,8 +41,15 @@ uses <a href="http://pyenv.github.io/pythons">http://pyenv.github.io/pythons</a>
 $ pyenv install 2.7.7
 </code></pre>
 
-<p>The filenames of the archives must be the md5sum of its content.
+<p>The filenames of the mirrored archives are their SHA-256 checksums.
 The following links are the contents of the pyenv's official mirror of Python archives.</p>
+
+          <h3>Prebuilt CPython</h3>
+
+<p>Prebuilt CPython archives and their python-build definitions.</p>
+
+          <ul id="prebuilt-cpython">
+          </ul>
 
           <h3>Stackless 2.7</h3>
 

--- a/pythons/test/update.sh
+++ b/pythons/test/update.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -e
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+write_meta() {
+  cat > binaries/3.14.0-ubuntu-24.04-x86_64.meta <<EOF
+# pyenv-binary metadata
+version=3.14.0
+os=Linux
+arch=x86_64
+platform=linux-x86_64
+distro=ubuntu 24.04
+libc=glibc 2.39
+build_prefix=/tmp/pyenv/versions/3.14.0-ubuntu-24.04-x86_64
+archive=$1
+EOF
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cp update.sh index.html "$tmpdir"
+mkdir "$tmpdir/binaries"
+printf archive-data > "$tmpdir/binaries/3.14.0-ubuntu-24.04-x86_64.tar.gz"
+printf definition > "$tmpdir/binaries/3.14.0-ubuntu-24.04-x86_64"
+
+cd "$tmpdir"
+write_meta 3.14.0-ubuntu-24.04-x86_64.tar.gz
+bash ./update.sh >/dev/null 2>&1 || fail "update failed"
+
+sha=8a6111c3ca752ed6d5f8e8a6daa3ba4b8c3b0bf55f00a87ac2b285024ef87e5f
+[ "binaries/3.14.0-ubuntu-24.04-x86_64.tar.gz" -ef "$sha" ] ||
+  fail "checksum path is not a hardlink to the archive"
+
+entry='<li><a href="binaries/3.14.0-ubuntu-24.04-x86_64.tar.gz">3.14.0-ubuntu-24.04-x86_64.tar.gz</a> (<a href="binaries/3.14.0-ubuntu-24.04-x86_64">definition</a>)</li>'
+grep -Fqx "$entry" index.html || fail "prebuilt archive is missing from index.html"
+
+cp index.html index.before
+bash ./update.sh >/dev/null 2>&1 || fail "second update failed"
+cmp -s index.before index.html || fail "second update changed index.html"
+[ "$(grep -Fxc "$entry" index.html)" -eq 1 ] || fail "prebuilt archive is listed more than once"
+
+write_meta ../outside.tar.gz
+printf outside > outside.tar.gz
+if bash ./update.sh >/dev/null 2>&1; then
+  fail "update accepted an archive outside binaries"
+fi
+
+write_meta 3.14.0-ubuntu-24.04-x86_64.tar.gz
+rm binaries/3.14.0-ubuntu-24.04-x86_64
+if bash ./update.sh >/dev/null 2>&1; then
+  fail "update accepted a missing definition"
+fi
+
+echo "ok"

--- a/pythons/test/update.sh
+++ b/pythons/test/update.sh
@@ -47,11 +47,25 @@ bash ./update.sh >/dev/null 2>&1 || fail "second update failed"
 cmp -s index.before index.html || fail "second update changed index.html"
 [ "$(grep -Fxc "$entry" index.html)" -eq 1 ] || fail "prebuilt archive is listed more than once"
 
+bad_name=$'bad\nname'
+printf 'archive=bad\narchive=name.tar.gz\n' > "binaries/$bad_name.meta"
+printf archive-data > "binaries/$bad_name.tar.gz"
+printf definition > "binaries/$bad_name"
+rm "$sha"
+if output="$(bash ./update.sh 2>&1)"; then
+  fail "update accepted a control character in an archive name"
+fi
+case "$output" in
+*"Invalid archive name in binaries/"*) ;;
+*) fail "update did not reject the invalid archive name during validation" ;;
+esac
+[ ! -e "$sha" ] || fail "update created a checksum link before name validation completed"
+rm "binaries/$bad_name.meta" "binaries/$bad_name.tar.gz" "binaries/$bad_name"
+
 mkdir source
 printf source-data > source/example.tar.gz
 printf '<li><a href="">example.tar.gz</a></li>\n' >> index.html
 cp index.html index.before
-rm "$sha"
 cp binaries/3.14.0-ubuntu-24.04-x86_64.meta binaries/z-invalid.meta
 sed -i 's/^archive=.*/archive=invalid.tar.gz/' binaries/z-invalid.meta
 if bash ./update.sh >/dev/null 2>&1; then

--- a/pythons/test/update.sh
+++ b/pythons/test/update.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+cd "${BASH_SOURCE%/*}/.."
+
 fail() {
   echo "$1" >&2
   exit 1
@@ -45,6 +47,22 @@ bash ./update.sh >/dev/null 2>&1 || fail "second update failed"
 cmp -s index.before index.html || fail "second update changed index.html"
 [ "$(grep -Fxc "$entry" index.html)" -eq 1 ] || fail "prebuilt archive is listed more than once"
 
+mkdir source
+printf source-data > source/example.tar.gz
+printf '<li><a href="">example.tar.gz</a></li>\n' >> index.html
+cp index.html index.before
+rm "$sha"
+cp binaries/3.14.0-ubuntu-24.04-x86_64.meta binaries/z-invalid.meta
+sed -i 's/^archive=.*/archive=invalid.tar.gz/' binaries/z-invalid.meta
+if bash ./update.sh >/dev/null 2>&1; then
+  fail "update accepted invalid metadata"
+fi
+[ ! -e "$sha" ] || fail "update created a binary checksum link before validation completed"
+source_sha=6bb69d845f4a714ca982e2903d2c03fabeb2448b67185bca413d3efddea9397c
+[ ! -e "$source_sha" ] || fail "update created a source checksum link before validation completed"
+cmp -s index.before index.html || fail "update changed index.html before validation completed"
+rm -rf source binaries/z-invalid.meta
+
 write_meta ../outside.tar.gz
 printf outside > outside.tar.gz
 if bash ./update.sh >/dev/null 2>&1; then
@@ -55,6 +73,12 @@ write_meta 3.14.0-ubuntu-24.04-x86_64.tar.gz
 rm binaries/3.14.0-ubuntu-24.04-x86_64
 if bash ./update.sh >/dev/null 2>&1; then
   fail "update accepted a missing definition"
+fi
+
+printf definition > binaries/3.14.0-ubuntu-24.04-x86_64
+rm binaries/3.14.0-ubuntu-24.04-x86_64.tar.gz
+if bash ./update.sh >/dev/null 2>&1; then
+  fail "update accepted a missing archive"
 fi
 
 echo "ok"

--- a/pythons/update.sh
+++ b/pythons/update.sh
@@ -61,6 +61,12 @@ for meta in binaries/*.meta; do
   [ -e "$meta" ] || continue
   name="$(basename "$meta" .meta)"
   archive="$(sed -n 's/^archive=//p' "$meta")"
+  case "$archive" in
+  "" | *[!A-Za-z0-9._-]*)
+    echo "Invalid archive name in $meta" >&2
+    exit 1
+    ;;
+  esac
   if [ "$archive" != "$name.tar.gz" ]; then
     echo "Invalid archive in $meta" >&2
     exit 1

--- a/pythons/update.sh
+++ b/pythons/update.sh
@@ -50,18 +50,12 @@ compute_md5() {
   fi
 }
 
-for file in source/*; do
-  [ -e "$file" ] || continue
-  base="$(basename "$file")"
-  #md5="$(compute_md5 < "$file")"
-  sha="$(compute_sha2 < "$file")"
-  #ln -f "$file" "$md5"
-  ln -f "$file" "$sha"
-  sed -i -e "/>$base</s/^.*$/<li><a href=\"$sha\">$base<\/a><\/li>/" index.html
-done
-
-list="$(mktemp)"
-trap 'rm -f "$list"' EXIT
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+list="$tmpdir/list"
+links="$tmpdir/links"
+: > "$list"
+: > "$links"
 
 for meta in binaries/*.meta; do
   [ -e "$meta" ] || continue
@@ -76,10 +70,24 @@ for meta in binaries/*.meta; do
     exit 1
   fi
   sha="$(compute_sha2 < "binaries/$archive")"
-  ln -f "binaries/$archive" "$sha"
+  printf '%s\n%s\n' "$archive" "$sha" >> "$links"
   printf '<li><a href="binaries/%s">%s</a> (<a href="binaries/%s">definition</a>)</li>\n' \
     "$archive" "$archive" "$name" >> "$list"
 done
+
+for file in source/*; do
+  [ -e "$file" ] || continue
+  base="$(basename "$file")"
+  #md5="$(compute_md5 < "$file")"
+  sha="$(compute_sha2 < "$file")"
+  #ln -f "$file" "$md5"
+  ln -f "$file" "$sha"
+  sed -i -e "/>$base</s/^.*$/<li><a href=\"$sha\">$base<\/a><\/li>/" index.html
+done
+
+while IFS= read -r archive && IFS= read -r sha; do
+  ln -f "binaries/$archive" "$sha"
+done < "$links"
 
 awk -v list="$list" '
   /<ul id="prebuilt-cpython">/ {

--- a/pythons/update.sh
+++ b/pythons/update.sh
@@ -9,8 +9,11 @@
 # 2. Download the archive from origin and save it in `./source`
 # 3. Run `./update.sh`
 # 4. Check diff of `./index.html` if the checksum is calculated properly
-# 5. Commit files with name of `md5sum` and `sha256sum` of the archive
+# 5. Commit the checksum-named archive files
 # 6. Push changes to the origin
+#
+# To add a prebuilt CPython, copy the archive, metadata and definition produced
+# by `pyenv binary package` to `./binaries`. The index entry is generated here.
 #
 
 set -e
@@ -48,6 +51,7 @@ compute_md5() {
 }
 
 for file in source/*; do
+  [ -e "$file" ] || continue
   base="$(basename "$file")"
   #md5="$(compute_md5 < "$file")"
   sha="$(compute_sha2 < "$file")"
@@ -55,5 +59,39 @@ for file in source/*; do
   ln -f "$file" "$sha"
   sed -i -e "/>$base</s/^.*$/<li><a href=\"$sha\">$base<\/a><\/li>/" index.html
 done
+
+list="$(mktemp)"
+trap 'rm -f "$list"' EXIT
+
+for meta in binaries/*.meta; do
+  [ -e "$meta" ] || continue
+  name="$(basename "$meta" .meta)"
+  archive="$(sed -n 's/^archive=//p' "$meta")"
+  if [ "$archive" != "$name.tar.gz" ]; then
+    echo "Invalid archive in $meta" >&2
+    exit 1
+  fi
+  if [ ! -f "binaries/$archive" ] || [ ! -f "binaries/$name" ]; then
+    echo "Missing archive or definition for $name" >&2
+    exit 1
+  fi
+  sha="$(compute_sha2 < "binaries/$archive")"
+  ln -f "binaries/$archive" "$sha"
+  printf '<li><a href="binaries/%s">%s</a> (<a href="binaries/%s">definition</a>)</li>\n' \
+    "$archive" "$archive" "$name" >> "$list"
+done
+
+awk -v list="$list" '
+  /<ul id="prebuilt-cpython">/ {
+    print
+    while ((getline line < list) > 0) print line
+    close(list)
+    replacing = 1
+    next
+  }
+  replacing && /<\/ul>/ { replacing = 0 }
+  !replacing { print }
+' index.html > index.html.tmp
+mv index.html.tmp index.html
 
 # vim:set ft=sh :


### PR DESCRIPTION
## What

Add a section to `pythons/index.html` for prebuilt CPython archives and their python-build definitions.

  ## Why

The existing downloads page only lists checksum-named source archives. Binary packages need stable named URLs and a readable listing without adding every artifact to the existing flat mirror list.

  ## How

Extend `pythons/update.sh` to read the archive name from each `.meta` file under `pythons/binaries/`, create the existing SHA-256 hardlink under `pythons/`, and rebuild the prebuilt CPython section. The updater rejects incomplete artifact sets and archive names that do not match their metadata.

Add `pythons/test/update.sh` to cover checksum links, index generation, repeated updates, invalid archive paths, and missing definitions.

  Part of pyenv/pyenv#2334.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a prebuilt CPython section to the downloads page so binary archives have stable URLs and readable listings alongside checksum-named source archives.

- `pythons/update.sh` reads `.meta` files, validates safe archive names and complete archive-definition pairs, then creates SHA-256 hardlinks and regenerates the section.
- The updater skips missing source files and leaves links and the index unchanged when validation fails.
- Adds coverage for hardlinks, idempotent index generation, invalid paths and names, and missing artifacts.
- Part of pyenv/pyenv#2334.

<sup>Written for commit 5e4e2c2a45e01d37b9799a4afa43db68c33c3912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pyenv/pyenv.github.io/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

